### PR TITLE
Rocker/ml Docker container with DeepCC

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,4 @@ RUN install2.r \
   xgboost cowplot
 
 RUN installGithub.r \
-  "CityUHK-CompBio/DeepCC"
+  "hypotheses/DeepCC"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM rocker/ml:3.6.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    build-essential \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+
+RUN git clone --recursive --branch 1.3.1 https://github.com/apache/incubator-mxnet.git \
+  &&  cd incubator-mxnet \
+  &&  make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
+
+RUN cd incubator-mxnet \
+  && make rpkg
+
+FROM rocker/ml:3.6.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-upgrade \
+    libopenblas-dev \
+    liblapack-dev \
+    libopencv-dev \
+    libxt-dev
+
+COPY --from=0 /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+
+RUN install2.r \
+  xgboost cowplot
+
+RUN installGithub.r \
+  "CityUHK-CompBio/DeepCC"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,30 @@
+# DeepCC Docker
+
+We have compiled Docker container for RStudio server with DeepCC. This is the deep leraning algorithm that help classify cancer type ([See Gao, et al. Oncogenesis, 2019](https://www.nature.com/articles/s41389-019-0157-8))
+
+The base image is from `rocker/ml:3.6.0` 
+
+With additional installation of R "DeepCC" library
+
+## To compile/build the container
+
+After you clone the repository,
+```
+cd docker
+docker build -t [repository]/[name]:[tag] .
+```
+
+## To launch the container
+```
+docker run -d -e PASSWORD=RStudio_Password --name deepcc -p 80:8787 [repository/[name]:[tag]
+```
+Replace `[repository/[name]:[tag]` with your docker hub repository or your desired name.
+
+## To use what we have compiled
+
+```
+docker pull hypotheses/rocker-ml-deepcc:3.6.0
+docker run -d --name deepcc -p 80:8787 hypotheses/rocker-ml-deepcc:3.6.0
+```
+- Your rstudio instance will be available at [http://localhost:80](http://localhost:80)
+- Default username for rocker container is 'rstudio' with the password 'RStudio_Password'


### PR DESCRIPTION
Build a container based on rocker/ml:3.6.0 with DeepCC installed to facilitate local installation of `mxnet` (branch version 1.3.1)